### PR TITLE
Update tsdav version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@saltcorn/caldav",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Table provider for Caldav (Calendar events)",
   "main": "index.js",
   "dependencies": {
     "@saltcorn/markup": "^1.0.0",
     "@saltcorn/data": "^1.0.0",
-    "tsdav": "2.1.3",
+    "tsdav": "2.1.5",
     "cal-parser": "1.0.2",
     "node-fetch": "2.6.9",
     "moment": "2.30.1",


### PR DESCRIPTION
tsdav 2.1.4 fixes an Apple iCloud CalDAV parsing bug, adds addressBookMultiGet support and 2.1.5 improves logging.

[tsdav changelog](https://github.com/natelindev/tsdav/blob/master/CHANGELOG.md)

I'm hoping either this update fixes saltcorn not showing Apple Calendar for selection (see screenshot), or enables additional logging that may help figure out whats going on.

![Capture](https://github.com/user-attachments/assets/05e50a2e-6719-475a-a59e-6f86e18ca63e)